### PR TITLE
フロントURLを環境変数で指定しない

### DIFF
--- a/client/src/pages/debug/index.tsx
+++ b/client/src/pages/debug/index.tsx
@@ -1,12 +1,16 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { MapForm } from '../../components/atoms/form/MapForm';
 import { TMapPosition } from '../../components/atoms/map/MapBasicInfo'; 
 import { BasicTemplate } from '../../components/templates/shared/BasicTemplate'; 
-export default function New() {
+
+export default function New() {  
+  useEffect(() => { 
+    console.log(window.location.origin)
+  },[])
   const [location, setLocation] = useState<null | TMapPosition>(null);  
   return (
     <BasicTemplate className="text-center"> 
       <MapForm location={location} setLocation={setLocation} />
     </BasicTemplate>
   );
-}
+} 

--- a/client/src/pages/event/[eventId]/completion/index.tsx
+++ b/client/src/pages/event/[eventId]/completion/index.tsx
@@ -29,8 +29,10 @@ export default function Participate() {
     },
     (error) => {}
   );
+  const [origin, setOrigin] = useState("")
   useEffect(() => {
     getEvent(eventId as string);
+    setOrigin(window.location.origin)
   }, []);
 
   return (
@@ -46,7 +48,7 @@ export default function Participate() {
           className="flex m-auto my-5"
           onClick={() => {
             copy(
-              `${process.env.NEXT_PUBLIC_FRONT_URL}/event/${eventId}/participate`
+              `${origin}/event/${eventId}/participate`
             );
           }}
         >

--- a/client/src/pages/event/[eventId]/participate/index.tsx
+++ b/client/src/pages/event/[eventId]/participate/index.tsx
@@ -14,6 +14,7 @@ import { Event } from '../../../../core/types/event';
 import { flow, pipe } from 'fp-ts/lib/function';
 import * as TE from 'fp-ts/TaskEither';
 import { joinEvent } from '../../../../core/api/event/join';
+import { useEffect } from 'react';
 
 export async function getServerSideProps(context: any) {
   const eventId = context.query.eventId;
@@ -39,16 +40,21 @@ export default function Participate(event: Event) {
   // TODO: SSRで実装してリンクを貼った時にOGPを表示させるようにする
   const [isConfirm, setIsConfirm] = useState(false);
   const router = useRouter();
+  const [origin, setOrigin] = useState("")
+  useEffect(() => { 
+    setOrigin(window.location.origin)
+  }, []);
   const joinApi = joinEvent(
     (response: unknown) => {
       router.push(
-        `${process.env.NEXT_PUBLIC_FRONT_URL}/event/${event.event_id}/`
+        `${origin}/event/${event.event_id}/`
       );
     },
     (e) => {}
   );
   const [name, setName] = useState('');
   const [word, setWord] = useState('');
+  
   return (
     <>
       <BasicTemplate className="text-center">

--- a/client/src/pages/event/new/index.tsx
+++ b/client/src/pages/event/new/index.tsx
@@ -10,13 +10,18 @@ import { MapForm } from '../../../components/atoms/form/MapForm';
 import { useUserInfoStore } from '../../../store/userStore';
 import { useRouter } from 'next/router';
 import { TMapPosition } from '../../../components/atoms/map/MapBasicInfo';
+import { useEffect } from 'react';
 
 export default function New() {
   const router = useRouter();
+  const [origin, setOrigin] = useState("")
+  useEffect(() => { 
+    setOrigin(window.location.origin)
+  }, []);
   const createEvent = createNewEvent(
     (ok) => {
       router.push(
-        `${process.env.NEXT_PUBLIC_FRONT_URL}/event/${ok.created_event.event_id}/completion`
+        `${origin}/event/${ok.created_event.event_id}/completion`
       );
     },
     (e) => {}


### PR DESCRIPTION
ref #51 

## 問題
localでbuildすると、デプロイ先のURLが、ページ遷移先やURLコピーが設定される。

## 原因
`yarn build` で読み込まれる環境変数`NEXT_PUBLIC_FRONT_URL`がデプロイ先のURLである。

## 解決
フロントURLを環境変数で指定しない。クライアント側で現在のURLを取得する。
